### PR TITLE
allow disable asyncpg logs

### DIFF
--- a/docs/async_orm.md
+++ b/docs/async_orm.md
@@ -94,9 +94,11 @@ config = AsyncOrmProvider(
 )
 ```
 
-Note: you can add any parameters that needed in order to configure the database connection.
+Disable asyncpg logging by set the parameter of `echo=False` in the `AsyncOrmProvider` object.
+more on engine parameters [here](https://docs.sqlalchemy.org/en/20/core/engines.html)
 
 `app_service.py`
+
 ```python
 from nest.core import Injectable
 
@@ -104,7 +106,7 @@ from nest.core import Injectable
 @Injectable
 class AppService:
     def __init__(self):
-        self.app_name = "MongoApp"
+        self.app_name = "AsyncOrmApp"
         self.app_version = "1.0.0"
 
     async def get_app_info(self):
@@ -112,6 +114,7 @@ class AppService:
 ```
 
 `app_controller.py`
+
 ```python
 from nest.core import Controller, Get
 
@@ -168,8 +171,10 @@ async def startup():
     await config.create_all()
 ```
 
-`@Module(...)`: This is a decorator that defines a module. In PyNest, a module is a class annotated with a `@Module()` decorator.
-The imports array includes the modules required by this module. In this case, ExampleModule is imported. The controllers and providers arrays are empty here, indicating this module doesn't directly provide any controllers or services.
+`@Module(...)`: This is a decorator that defines a module. In PyNest, a module is a class annotated with a `@Module()`
+decorator.
+The imports array includes the modules required by this module. In this case, ExampleModule is imported. The controllers
+and providers arrays are empty here, indicating this module doesn't directly provide any controllers or services.
 
 `PyNestFactory.create()` is a command to create an instance of the application.
 The AppModule is passed as an argument, which acts as the root module of the application.
@@ -188,8 +193,6 @@ other parameters for efficient database access.
 
 AsyncSession from sqlalchemy.ext.asyncio is used for executing asynchronous database operations. It is essential for
 leveraging the full capabilities of SQLAlchemy 2.0 in an async environment.
-
-
 
 ## Implementing Async Features
 
@@ -305,11 +308,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 @Controller("examples")
 class ExamplesController:
-    
-   def __init__(self, service: ExamplesService):
+
+    def __init__(self, service: ExamplesService):
         self.service = service
 
     @Get("/")
+
     async def get_examples(self, session: AsyncSession = Depends(config.get_db)):
         return await self.service.get_examples(session)
 
@@ -330,11 +334,12 @@ from .examples_model import Examples
 
 @Controller("examples")
 class ExamplesController:
-   
-   def __init__(self, service: ExamplesService):
+
+    def __init__(self, service: ExamplesService):
         self.service = service
 
     @Get("/")
+
     async def get_examples(self):
         return await self.service.get_examples()
 

--- a/nest/core/database/orm_provider.py
+++ b/nest/core/database/orm_provider.py
@@ -99,7 +99,8 @@ class AsyncOrmProvider(BaseOrmProvider):
     def __init__(
         self, db_type: str = "postgresql", config_params: dict = None, **kwargs
     ):
-        kwargs["engine_params"] = dict(echo=True)
+        echo = kwargs.get("echo", True)
+        kwargs["engine_params"] = dict(echo=echo)
         kwargs["session_params"] = dict(expire_on_commit=False, class_=AsyncSession)
         super().__init__(
             db_type=db_type, config_params=config_params, async_mode=True, **kwargs


### PR DESCRIPTION
This pull request primarily focuses on changes in the `docs/async_orm.md` file and the `nest/core/database/orm_provider.py` file. The changes in `docs/async_orm.md` involve updates to the documentation to reflect changes in the codebase, including changes to the `config = AsyncOrmProvider(` and `async def startup():` sections, as well as the removal of two lines of text. The changes to `nest/core/database/orm_provider.py` involve modifying the `AsyncOrmProvider` class to allow for the disabling of asyncpg logging.

Documentation updates:

* [`docs/async_orm.md`](diffhunk://#diff-fff1c8f19290fe1a6e300e0f70f9ec0b086d2360833eb640557d218a45a1e44cL97-R117): Updated the `config = AsyncOrmProvider(` section to include information about disabling asyncpg logging and provided a link to more information on engine parameters. The `app_name` in the `AppService` class has also been changed from "MongoApp" to "AsyncOrmApp".
* [`docs/async_orm.md`](diffhunk://#diff-fff1c8f19290fe1a6e300e0f70f9ec0b086d2360833eb640557d218a45a1e44cL171-R177): Made minor formatting changes to the `async def startup():` section for better readability.
* [`docs/async_orm.md`](diffhunk://#diff-fff1c8f19290fe1a6e300e0f70f9ec0b086d2360833eb640557d218a45a1e44cL192-L193): Removed two lines of text under the section discussing the use of `AsyncSession` from `sqlalchemy.ext.asyncio`.
* [`docs/async_orm.md`](diffhunk://#diff-fff1c8f19290fe1a6e300e0f70f9ec0b086d2360833eb640557d218a45a1e44cR316): Added new lines in the `get_examples` method of the `ExamplesController` class for better readability. [[1]](diffhunk://#diff-fff1c8f19290fe1a6e300e0f70f9ec0b086d2360833eb640557d218a45a1e44cR316) [[2]](diffhunk://#diff-fff1c8f19290fe1a6e300e0f70f9ec0b086d2360833eb640557d218a45a1e44cR342)

Codebase modification:

* [`nest/core/database/orm_provider.py`](diffhunk://#diff-b53c3129b7f094687bf9bc3af0ee5d1366185d31c8528a2abc70a55eac5b2c45L102-R103): Modified the `AsyncOrmProvider` class to allow for the disabling of asyncpg logging by setting the `echo` parameter to `False`. This is reflected in the updated documentation in `docs/async_orm.md`.