### PR TITLE
Change Module Decorator to dataclass

### DIFF
--- a/nest/core/decorators/module.py
+++ b/nest/core/decorators/module.py
@@ -1,20 +1,15 @@
 from nest.common.constants import ModuleMetadata
+from typing import List
+import dataclasses
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
 class Module:
-    def __init__(
-        self,
-        imports=None,
-        controllers=None,
-        providers=None,
-        exports=None,
-        is_global: bool = False,
-    ):
-        self.controllers = controllers or []
-        self.providers = providers or []
-        self.imports = imports or []
-        self.exports = exports
-        self.is_global = is_global
+    controllers: List[type] = dataclasses.field(default_factory=list)
+    providers: List[type] = dataclasses.field(default_factory=list)
+    exports: List[type] = dataclasses.field(default_factory=list)
+    imports: List[type] = dataclasses.field(default_factory=list)
+    is_global: List[type] = dataclasses.field(default=False)
 
     def __call__(self, cls):
         setattr(cls, ModuleMetadata.CONTROLLERS, self.controllers)

--- a/nest/core/decorators/utils.py
+++ b/nest/core/decorators/utils.py
@@ -24,6 +24,7 @@ def _is_valid_instance_variable(target):
         and target.value.id == "self"
     )
 
+
 def get_instance_variables(cls):
     """
     Retrieves instance variables assigned in the __init__ method of a class,
@@ -72,10 +73,12 @@ def _check_injectable_in_object(param: inspect.Parameter) -> bool:
         and INJECTABLE_TOKEN in param.annotation.__dict__
     )
 
+
 def _check_injectable_in_object_and_parents(param: inspect.Parameter) -> bool:
     return param.annotation != param.empty and getattr(
         param.annotation, INJECTABLE_TOKEN, False
     )
+
 
 def parse_dependencies(cls: Type, check_parent: bool = False) -> Dict[str, Type]:
     """
@@ -83,12 +86,13 @@ def parse_dependencies(cls: Type, check_parent: bool = False) -> Dict[str, Type]
         mapping of injectable parameters name to there annotation
     """
     signature = inspect.signature(cls.__init__)
-    filter_by = _check_injectable_in_object_and_parents if check_parent else _check_injectable_in_object
+    filter_by = (
+        _check_injectable_in_object_and_parents
+        if check_parent
+        else _check_injectable_in_object
+    )
     params: List[inspect.Parameter] = filter(filter_by, signature.parameters.values())
-    return {
-        param.name: param.annotation
-        for param in params
-    }
+    return {param.name: param.annotation for param in params}
 
 
 def parse_params(func: Callable) -> List[click.Option]:

--- a/nest/core/decorators/utils.py
+++ b/nest/core/decorators/utils.py
@@ -66,7 +66,7 @@ def get_non_dependencies_params(cls: Type):
     }
 
 
-def _check_injectable_in_object(param: inspect.Parameter) -> bool:
+def _check_injectable_not_inherited(param: inspect.Parameter) -> bool:
     return (
         param.annotation != param.empty
         and hasattr(param.annotation, "__dict__")
@@ -74,22 +74,22 @@ def _check_injectable_in_object(param: inspect.Parameter) -> bool:
     )
 
 
-def _check_injectable_in_object_and_parents(param: inspect.Parameter) -> bool:
+def _check_injectable_inherited(param: inspect.Parameter) -> bool:
     return param.annotation != param.empty and getattr(
         param.annotation, INJECTABLE_TOKEN, False
     )
 
 
-def parse_dependencies(cls: Type, check_parent: bool = False) -> Dict[str, Type]:
+def parse_dependencies(cls: Type, check_inherited: bool = False) -> Dict[str, Type]:
     """
     Returns:
         mapping of injectable parameters name to there annotation
     """
     signature = inspect.signature(cls.__init__)
     filter_by = (
-        _check_injectable_in_object_and_parents
-        if check_parent
-        else _check_injectable_in_object
+        _check_injectable_inherited
+        if check_inherited
+        else _check_injectable_not_inherited
     )
     params: List[inspect.Parameter] = filter(filter_by, signature.parameters.values())
     return {param.name: param.annotation for param in params}

--- a/nest/core/decorators/utils.py
+++ b/nest/core/decorators/utils.py
@@ -1,6 +1,6 @@
 import ast
 import inspect
-from typing import Callable, List
+from typing import Callable, List, Dict, Type, Set
 
 import click
 
@@ -23,67 +23,68 @@ def get_instance_variables(cls):
         tree = ast.parse(source)
 
         # Getting the parameter names to exclude dependencies
-        dependencies = set(
-            param.name
-            for param in inspect.signature(cls.__init__).parameters.values()
-            if param.annotation != param.empty
-            and getattr(param.annotation, "__injectable__", False)
-        )
-
-        instance_vars = {}
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if (
-                        isinstance(target, ast.Attribute)
-                        and isinstance(target.value, ast.Name)
-                        and target.value.id == "self"
-                    ):
-                        # Exclude dependencies
-                        if target.attr not in dependencies:
-                            # Here you can either store the source code of the value or
-                            # evaluate it in the class' context, depending on your needs
-                            instance_vars[target.attr] = ast.get_source_segment(
-                                source, node.value
-                            )
-        return instance_vars
-    except Exception as e:
+        dependencies: Dict[str, ...] = parse_dependencies(cls, check_parent=True)
+        assign_nodes = filter(lambda node: isinstance(node, ast.Assign), ast.walk(tree))
+        return {
+            # Here you can either store the source code of the value or
+            # evaluate it in the class' context, depending on your needs
+            target.attr: ast.get_source_segment(source, node.value)
+            for node in assign_nodes
+            for target in node.targets
+            if isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+            and target.attr not in dependencies  # Exclude dependencies
+        }
+    except Exception:
         return {}
 
 
-def get_non_dependencies_params(cls):
+def get_non_dependencies_params(cls: Type):
     source = inspect.getsource(cls.__init__).strip()
     tree = ast.parse(source)
-    non_dependencies = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Attribute):
-            non_dependencies[node.attr] = node.value.id
-    return non_dependencies
+    return {
+        node.attr: node.value.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+    }
 
 
-def parse_dependencies(cls):
+def parse_dependencies(cls: Type, check_parent: bool = False) -> Dict[str, Type]:
+    """
+    Returns:
+        mapping of injectable parameters name to there annotation
+    """
+
+    def _check_only_child(param: inspect.Parameter) -> bool:
+        return (
+            param.annotation != param.empty
+            and hasattr(param.annotation, "__dict__")
+            and INJECTABLE_TOKEN in param.annotation.__dict__
+        )
+
+    def _check_with_parent(param: inspect.Parameter) -> bool:
+        return param.annotation != param.empty and getattr(
+            param.annotation, INJECTABLE_TOKEN, False
+        )
+
     signature = inspect.signature(cls.__init__)
-    dependecies = {}
-    for param in signature.parameters.values():
-        try:
-            if (
-                param.annotation != param.empty
-                and hasattr(param.annotation, "__dict__")
-                and INJECTABLE_TOKEN in param.annotation.__dict__
-            ):
-                dependecies[param.name] = param.annotation
-        except Exception as e:
-            raise e
-    return dependecies
+    filter_by = _check_with_parent if check_parent else _check_only_child
+    return {
+        param.name: param.annotation
+        for param in signature.parameters.values()
+        if filter_by(param)
+    }
 
 
 def parse_params(func: Callable) -> List[click.Option]:
+    """
+    Returns:
+        all parameters with annotation
+    """
     signature = inspect.signature(func)
-    params = []
-    for param in signature.parameters.values():
-        try:
-            if param.annotation != param.empty:
-                params.append(param.annotation)
-        except Exception as e:
-            raise e
-    return params
+    return [
+        param.annotation
+        for param in signature.parameters.values()
+        if param.annotation != param.empty
+    ]


### PR DESCRIPTION
Rewrote some of the logic of data-class that allow the use of slots (better access time) and allow fo easy factory creation with no need for none params with or [].