### PR TITLE
ci(release): auto-populate GitHub release notes and changelog sections

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
         run: uv sync --no-dev --group build
 
       - name: Update CHANGELOG.md
-        run: uv run git-changelog . -o "$CHANGELOG_FILE_PATH"
+        run: uv run git-changelog . -o "$CHANGELOG_FILE_PATH" --bump "v$RELEASE_VERSION"
 
       - name: Build package
         run: uv build --sdist --wheel
@@ -109,6 +109,7 @@ jobs:
         with:
           name: v${{ env.RELEASE_VERSION }}
           tag_name: v${{ env.RELEASE_VERSION }}
+          generate_release_notes: true
 
   deploy-docs:
     needs: release-package


### PR DESCRIPTION
## Summary

The current release pipeline cuts a tag, publishes to PyPI, and creates an empty GitHub release. v0.6.0 (which shipped websocket gateways) has `body: ""` and `CHANGELOG.md` only contains an empty `## Unreleased` block — so launches go out silently.

Two one-line fixes:

- **`generate_release_notes: true`** on `softprops/action-gh-release@v2`. GitHub builds the release body from merged PRs since the previous tag (titles, authors, full-changelog link). No commit-message format dependency.
- **`--bump "v$RELEASE_VERSION"`** on `git-changelog`. Without it, the tool can't promote the `Unreleased` block into a versioned section, so `CHANGELOG.md` never accumulates entries. The `v` prefix matches the existing tag scheme so compare links resolve.

## Test plan
- [ ] Trigger `release.yaml` (workflow_dispatch, `patch`) once this is merged
- [ ] Confirm the published GitHub release has a non-empty body with PR list
- [ ] Confirm `CHANGELOG.md` on `main` gains a `## [vX.Y.Z]` section after the run